### PR TITLE
Update amplify-plugin.json

### DIFF
--- a/packages/amplify-openapi-backend/amplify-plugin.json
+++ b/packages/amplify-openapi-backend/amplify-plugin.json
@@ -6,7 +6,7 @@
   "functionTemplate": {
     "conditions": {
       "provider": "awscloudformation",
-      "service": "Lambda",
+      "services": ["Lambda"],
       "runtime": "nodejs"
     },
     "templates": [


### PR DESCRIPTION
The newest version of the amplify CLI API requires to define `functionTemplate.conditions.services` rather than `functionTemplate.conditions.service` and pass to it a list of services (`["Lambda"]`)

Otherwise installing the plugin and using the `amplify api add` CLI ends up at some point with this error (when about to select the function template):
```
TypeError: Cannot read property 'includes' of undefined
```